### PR TITLE
add Dockerfile for OpenShift deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM dukegcb/openshift-shiny-verse:4.0.2
+ADD ./_site /srv/code
+RUN install2.r metathis distill learnr here ggrepel viridis gghighlight twitterwidget patchwork
+RUN Rscript -e 'devtools::install_github("matthewhirschey/bespokelearnr")'


### PR DESCRIPTION
This docker image will serve the `_site` directory using shiny-server.
It also installs the requirements for this code.

NOTE: there is a problem with the slides urls on the main page.
They are "slides/index.html" and should be "slides/" to work with shiny server.
Right now the Slides iframe shows "Not Found" and the "Slides" link take you to a "Not Found" page.
I am not sure how all these files are build so not sure where to make a fix for that.
The fix should just be removing the "index.html" part.

